### PR TITLE
Add keylocker signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Set up Java for signing
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
-          distribution: 'liberica'
+          java-version: '11'
+          distribution: 'zulu'
+          java-package: 'jre'
 
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'oracle'
+          distribution: 'zulu'
 
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
+          distribution: 'zulu'
 
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,9 @@ jobs:
         shell: bash
 
       - name: Sign binary
+        working-directory: clickhouse-tableau-jdbc/signing_utility
         run: | 
+          pwd
           jarsigner -keystore NONE  -storepass NONE -storetype PKCS11 -sigalg SHA256withRSA -providerClass sun.security.pkcs11.SunPKCS11 -providerArg pkcs11properties.cfg -signedjar  clickhouse_jdbc_signed.taco  $TACO_FILE $DIGICERT_KEY_ALIAS  -tsa  http://timestamp.digicert.com
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Java for signing
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '11'
           distribution: 'oracle'
 
       - name: Prepare for signing 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Set up Java for signing
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'zulu'
+          java-version: '11'
+          distribution: 'microsoft'
 
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'zulu'
-          java-package: 'jre'
 
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility
@@ -49,6 +48,7 @@ jobs:
           echo "SM_CLIENT_CERT_FILE=/tmp/Certificate_pkcs12.p12" >> "$GITHUB_ENV" 
           echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV" 
           echo "DIGICERT_KEY_ALIAS=${{ secrets.DIGICERT_KEY_ALIAS }}" >> "$GITHUB_ENV"
+          ls /tmp
         shell: bash
 
       - name: Sign binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Java for signing
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'zulu'
 
       - name: Prepare for signing 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility
         run: | 
-          cp ./smpkcs11.dylib /tmp/smpkcs11.dylib
+          cp ./smpkcs11.so /tmp/smpkcs11.so
           echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /tmp/Certificate_pkcs12.p12 
           echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV" 
           echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV" 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Set up Java for signing
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'temurin'
+          java-version: '11'
+          distribution: 'liberica'
 
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Java for signing
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'liberica'
 
       - name: Prepare for signing 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,17 @@ jobs:
         with:
           repository: tableau/connector-plugin-sdk
           ref: tableau-2023.2
+
       - name: Checkout ClickHouse Tableau JDBC connector
         uses: actions/checkout@v3
         with:
           path: clickhouse-tableau-jdbc
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+
       - name: Package the connector
         working-directory: connector-packager
         run: |
@@ -27,9 +30,33 @@ jobs:
           source ./.venv/bin/activate
           python setup.py install
           python -m connector_packager.package ../clickhouse-tableau-jdbc/clickhouse_jdbc
+          echo "TACO_FILE=$(find "$PWD" -name 'clickhouse*.taco' | head -n 1)" >> $GITHUB_ENV
+
+      - name: Set up Java for signing
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+
+      - name: Prepare for signing 
+        working-directory: clickhouse-tableau-jdbc/signing_utility
+        run: | 
+          cp ./smpkcs11.dylib /tmp/smpkcs11.dylib
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /tmp/Certificate_pkcs12.p12 
+          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV" 
+          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV" 
+          echo "SM_CLIENT_CERT_FILE=/tmp/Certificate_pkcs12.p12" >> "$GITHUB_ENV" 
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV" 
+          echo "DIGICERT_KEY_ALIAS=${{ secrets.DIGICERT_KEY_ALIAS }}" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Sign binary
+        run: | 
+          jarsigner -keystore NONE  -storepass NONE -storetype PKCS11 -sigalg SHA256withRSA -providerClass sun.security.pkcs11.SunPKCS11 -providerArg pkcs11properties.cfg -signedjar  clickhouse_jdbc_signed.taco  $TACO_FILE $DIGICERT_KEY_ALIAS  -tsa  http://timestamp.digicert.com
+        shell: bash
+
       - name: Upload the taco
         uses: actions/upload-artifact@v3
         with:
-          name: clickhouse_jdbc.taco
-          path: connector-packager/packaged-connector/clickhouse_jdbc*.taco
+          name: clickhouse_jdbc_signed.taco
+          path: clickhouse-tableau-jdbc/signing_utility/clickhouse_jdbc_signed.taco
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'oracle'
 
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,11 @@ jobs:
           echo "SM_CLIENT_CERT_FILE=/tmp/Certificate_pkcs12.p12" >> "$GITHUB_ENV" 
           echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV" 
           echo "DIGICERT_KEY_ALIAS=${{ secrets.DIGICERT_KEY_ALIAS }}" >> "$GITHUB_ENV"
-          ls /tmp
         shell: bash
 
       - name: Sign binary
         working-directory: clickhouse-tableau-jdbc/signing_utility
         run: | 
-          pwd
           jarsigner -keystore NONE  -storepass NONE -storetype PKCS11 -sigalg SHA256withRSA -providerClass sun.security.pkcs11.SunPKCS11 -providerArg pkcs11properties.cfg -signedjar  clickhouse_jdbc_signed.taco  $TACO_FILE $DIGICERT_KEY_ALIAS  -tsa  http://timestamp.digicert.com
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'temurin'
 
       - name: Prepare for signing 
         working-directory: clickhouse-tableau-jdbc/signing_utility

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Java for signing
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'temurin'
 
       - name: Prepare for signing 

--- a/signing_utility/pkcs11properties.cfg
+++ b/signing_utility/pkcs11properties.cfg
@@ -1,0 +1,3 @@
+name=signingmanager 
+library=/tmp/smpkcs11.dylib
+slotListIndex=0

--- a/signing_utility/pkcs11properties.cfg
+++ b/signing_utility/pkcs11properties.cfg
@@ -1,3 +1,3 @@
 name=signingmanager 
-library=/tmp/smpkcs11.dylib
+library=/tmp/smpkcs11.so
 slotListIndex=0


### PR DESCRIPTION
@slvrtrn - Finally got the signing working ... Please take a look https://github.com/ClickHouse/clickhouse-tableau-connector-jdbc/actions/runs/6969101537 

but  I have artefact as "[clickhouse_jdbc_signed.taco](https://github.com/ClickHouse/clickhouse-tableau-connector-jdbc/suites/18441499567/artifacts/1069202568)" .. do you want the version name with it too? may have to do some `sed` if that's the case.

Sorry for the horrendous list of commits... I made a mistake in the signing lib (used macos version instead of nix one ... duh) and the error from jarsigner was not helpful but that mistake is corrected now.