### PR TITLE
Update upload-artifact version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
 
       - name: Upload the taco
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: clickhouse_jdbc_signed.taco
           path: clickhouse-tableau-jdbc/signing_utility/clickhouse_jdbc_signed.taco


### PR DESCRIPTION
Upload artifact v3 is deprecating on November 30th so we are upgrading to V4 

Related: https://github.com/actions/upload-artifact